### PR TITLE
refactor: JSONCompareMode を配列の有無に合わせて統一

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -232,7 +232,7 @@ class ArticleTest {
                 expectedResponseBody,
                 actualResponseBody,
                 CustomComparator(
-                    JSONCompareMode.NON_EXTENSIBLE,
+                    JSONCompareMode.STRICT,
                     Customization("article.slug") { actualSlug, _ ->
                         actualSlug.toString().matches(Regex("^[a-z0-9]{32}\$"))
                     }
@@ -292,7 +292,7 @@ class ArticleTest {
             JSONAssert.assertEquals(
                 expectedResponseBody,
                 actualResponseBody,
-                JSONCompareMode.STRICT,
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
     }
@@ -468,7 +468,7 @@ class ArticleTest {
                 expectedResponseBody,
                 actualResponseBody,
                 CustomComparator(
-                    JSONCompareMode.NON_EXTENSIBLE,
+                    JSONCompareMode.STRICT,
                 )
             )
         }
@@ -524,7 +524,7 @@ class ArticleTest {
             JSONAssert.assertEquals(
                 expectedResponseBody,
                 actualResponseBody,
-                JSONCompareMode.STRICT,
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
 
@@ -581,7 +581,7 @@ class ArticleTest {
             JSONAssert.assertEquals(
                 expectedResponseBody,
                 actualResponseBody,
-                JSONCompareMode.STRICT,
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
     }
@@ -679,7 +679,7 @@ class ArticleTest {
             JSONAssert.assertEquals(
                 expectedResponseBody,
                 actualResponseBody,
-                JSONCompareMode.STRICT,
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
     }


### PR DESCRIPTION
- https://github.com/Msksgm/hands-on-server-side-kotlin/issues/53