### PR TITLE
feat: 「📃3.3 ドメインオブジェクトの実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Body.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Body.kt
@@ -1,0 +1,85 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.leftNel
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 作成済記事の本文の値オブジェクト
+ *
+ */
+interface Body {
+    /**
+     * 本文
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事の本文
+     *
+     * @property value
+     */
+    private data class ValidatedBody(override val value: String) : Body
+
+    /**
+     * Validation 無し、作成済記事の本文
+     *
+     * @property value
+     */
+    private data class BodyWithoutValidation(override val value: String) : Body
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength: Int = 1024
+
+        /**
+         * Validation 無し
+         *
+         * @param body
+         * @return
+         */
+        fun newWithoutValidation(body: String): Body = BodyWithoutValidation(body)
+
+        /**
+         * Validation 有り
+         *
+         * @param body
+         * @return
+         */
+        fun new(body: String): EitherNel<CreationError, Body> {
+            /**
+             * 文字数チェック
+             *
+             * 最大文字数より長かったら、早期リターン
+             */
+            if (body.length > maximumLength) {
+                return CreationError.TooLong(maximumLength).leftNel()
+            }
+
+            return ValidatedBody(body).right()
+        }
+    }
+
+    /**
+     * オブジェクト生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "body は $maximum 文字以下にしてください"
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticle.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticle.kt
@@ -1,0 +1,86 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 作成済記事
+ *
+ * エンティティ
+ *
+ * @property slug
+ * @property title
+ * @property description
+ * @property body
+ */
+class CreatedArticle private constructor(
+    val slug: Slug,
+    val title: Title,
+    val description: Description,
+    val body: Body,
+) {
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        /**
+         * Validation 有り、作成済記事を生成
+         *
+         * @param title
+         * @param description
+         * @param body
+         * @return
+         */
+        fun new(
+            title: String,
+            description: String,
+            body: String,
+        ): EitherNel<ValidationError, CreatedArticle> {
+            return either {
+                zipOrAccumulate(
+                    { Title.new(title).bindNel() },
+                    { Description.new(description).bindNel() },
+                    { Body.new(body).bindNel() }
+                ) { validatedTitle, validatedDescription, validatedBody ->
+                    CreatedArticle(Slug.new(), validatedTitle, validatedDescription, validatedBody)
+                }
+            }
+        }
+
+        /**
+         * Validation 無し、作成済記事を生成
+         *
+         * @param slug
+         * @param title
+         * @param description
+         * @param body
+         * @return
+         */
+        fun newWithoutValidation(
+            slug: Slug,
+            title: Title,
+            description: Description,
+            body: Body,
+        ): CreatedArticle = CreatedArticle(
+            slug,
+            title,
+            description,
+            body
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is CreatedArticle) {
+            return false
+        }
+        return this.slug == other.slug
+    }
+
+    override fun hashCode(): Int {
+        return slug.hashCode() * 31
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Description.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Description.kt
@@ -1,0 +1,85 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.leftNel
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 「作成済記事の概要」の値オブジェクト
+ *
+ */
+interface Description {
+    /**
+     * 概要
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事の概要
+     *
+     * @property value
+     */
+    private data class ValidatedDescription(override val value: String) : Description
+
+    /**
+     * Validation 無し、作成済記事の概要
+     *
+     * @property value
+     */
+    private data class DescriptionWithoutValidation(override val value: String) : Description
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength: Int = 64
+
+        /**
+         * Validation 有り
+         *
+         * @param description
+         * @return
+         */
+        fun new(description: String): EitherNel<CreationError, Description> {
+            /**
+             * 文字数チェック
+             *
+             * 最大文字数より長かったら、早期リターン
+             */
+            if (description.length > maximumLength) {
+                return CreationError.TooLong(maximumLength).leftNel()
+            }
+
+            return ValidatedDescription(description).right()
+        }
+
+        /**
+         * Validation 無し
+         *
+         * @param description
+         * @return
+         */
+        fun newWithoutValidation(description: String): Description = DescriptionWithoutValidation(description)
+    }
+
+    /**
+     * オブジェクト生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "description は $maximum 文字以下にしてください"
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Slug.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Slug.kt
@@ -1,0 +1,90 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.leftNel
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import java.util.UUID
+
+/**
+ * 作成済記事の Slug
+ *
+ */
+interface Slug {
+    /**
+     * slug の値
+     */
+    val value: String
+
+    /**
+     * new から生成された slug
+     *
+     * @property value
+     */
+    private data class ValidatedSlug(override val value: String) : Slug
+
+    /**
+     * new 以外から生成された slug
+     *
+     * @property value
+     */
+    private data class SlugWithoutValidation(override val value: String) : Slug
+
+    companion object {
+        private const val format: String = "^[a-z0-9]{32}$"
+
+        /**
+         * Validation なし
+         *
+         * @param slug
+         * @return
+         */
+        fun newWithoutValidation(slug: String): Slug = SlugWithoutValidation(slug)
+
+        /**
+         * Validation あり
+         *
+         * @param slug
+         * @return
+         */
+        fun new(slug: String): EitherNel<CreationError, Slug> {
+            /**
+             * format チェック
+             *
+             * format が適切でなかったら、早期リターン
+             */
+            if (!slug.matches(Regex(format))) {
+                return CreationError.ValidFormat(slug).leftNel()
+            }
+
+            return ValidatedSlug(slug).right()
+        }
+
+        /**
+         * 引数有りの場合、UUID から生成
+         *
+         * @return
+         */
+        fun new(): Slug {
+            return ValidatedSlug(UUID.randomUUID().toString().split("-").joinToString(""))
+        }
+    }
+
+    /**
+     * Slug 生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * フォーマット確認
+         *
+         * 指定された format 以外は駄目
+         *
+         * @property slug
+         */
+        data class ValidFormat(val slug: String) : CreationError {
+            override val message: String
+                get() = "slug は 32 文字の英小文字数字です。"
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Title.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/Title.kt
@@ -1,0 +1,105 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.leftNel
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 作成済記事のタイトルの値オブジェクト
+ */
+interface Title {
+    /**
+     * タイトル名
+     */
+    val value: String
+
+    /**
+     * Validation 有り、作成済記事のタイトル
+     *
+     * @property value
+     */
+    private data class ValidatedTitle(override val value: String) : Title
+
+    /**
+     * Validation 無し、作成済記事のタイトル
+     *
+     * @property value
+     */
+    private data class TitleWithoutValidation(override val value: String) : Title
+
+    /**
+     * Factory メソッド
+     *
+     * @constructor Create empty Companion
+     */
+    companion object {
+        private const val maximumLength = 32
+
+        /**
+         * Validation 無し
+         *
+         * @param title
+         * @return
+         */
+        fun newWithoutValidation(title: String): Title = TitleWithoutValidation(title)
+
+        /**
+         * Validation 有り
+         *
+         * @param title
+         * @return
+         */
+        fun new(title: String): EitherNel<CreationError, Title> {
+            /**
+             * 空白チェック
+             *
+             * 空白だった場合、早期リターン
+             */
+            if (title.isBlank()) {
+                return CreationError.Required.leftNel()
+            }
+
+            /**
+             * 文字数確認
+             *
+             * 最大文字数より長かったら、早期リターン
+             */
+            if (title.length > maximumLength) {
+                return CreationError.TooLong(maximumLength).leftNel()
+            }
+
+            return ValidatedTitle(title).right()
+        }
+    }
+
+    /**
+     * タイトル生成時のドメインルール
+     *
+     */
+    sealed interface CreationError : ValidationError {
+        /**
+         * 必須
+         *
+         * 空文字列や空白を許容しない
+         *
+         * @constructor Create empty Required
+         */
+        object Required : CreationError {
+            override val message: String
+                get() = "title は必須です"
+        }
+
+        /**
+         * 文字数制限
+         *
+         * 長すぎては駄目
+         *
+         * @property maximum
+         */
+        data class TooLong(val maximum: Int) : CreationError {
+            override val message: String
+                get() = "title は $maximum 文字以下にしてください。"
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/util/ValidationError.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/util/ValidationError.kt
@@ -1,0 +1,14 @@
+package com.example.implementingserversidekotlindevelopment.util
+
+/**
+ * ドメインオブジェクトのバリデーションにおけるエラー型
+ *
+ * 必ずエラーメッセージを記述する
+ *
+ */
+interface ValidationError {
+    /**
+     * エラーメッセージ
+     */
+    val message: String
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/BodyTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/BodyTest.kt
@@ -1,0 +1,67 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+import arrow.core.leftNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+
+class BodyTest {
+    class New {
+        @Property
+        fun `正常系 長さが有効な場合、検証済の作成済記事の Body が戻り値`(
+            @ForAll @From(supplier = BodyValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Body.new(validString)
+
+            /**
+             * then:
+             */
+            val expected = Body.newWithoutValidation(validString)
+            when (actual) {
+                is Either.Left -> assert(false) { "原因: ${actual.value}" }
+                is Either.Right -> assertThat(actual.value.value).isEqualTo(expected.value)
+            }
+        }
+
+        @Property
+        fun `異常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @StringLength(min = 1025) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 1024
+
+            /**
+             * when:
+             */
+            val actual = Body.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Body.CreationError.TooLong(maximumLength).leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    class BodyValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .ofMinLength(0)
+                .ofMaxLength(1024)
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/CreatedArticleTest.kt
@@ -1,0 +1,71 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
+
+class CreatedArticleTest {
+    data class TestCase(
+        val title: String,
+        val createdArticle: CreatedArticle,
+        val otherCreatedArticle: CreatedArticle,
+        val expected: Boolean,
+    )
+
+    @TestFactory
+    fun articleEqualTest(): Stream<DynamicNode> {
+        return Stream.of(
+            TestCase(
+                "Slug が一致する場合、他のプロパティが異なっていても、true を戻す",
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"),
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"), // slug が同じ
+                    title = Title.newWithoutValidation("other-dummy-title"),
+                    description = Description.newWithoutValidation("other-dummy-description"),
+                    body = Body.newWithoutValidation("other-dummy-body")
+                ),
+                true
+            ),
+            TestCase(
+                "Slug が一致しない場合、他のプロパティが一致していても、false を戻す",
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("dummy-slug"),
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                CreatedArticle.newWithoutValidation(
+                    slug = Slug.newWithoutValidation("other-dummy-slug"), // slug が異なる
+                    title = Title.newWithoutValidation("dummy-title"),
+                    description = Description.newWithoutValidation("dummy-description"),
+                    body = Body.newWithoutValidation("dummy-body")
+                ),
+                false
+            )
+        ).map { testCase ->
+            dynamicTest(testCase.title) {
+                /**
+                 * given:
+                 */
+
+                /**
+                 * when:
+                 * - 作成済み記事を比較
+                 */
+                val actual = testCase.createdArticle == testCase.otherCreatedArticle
+
+                /**
+                 * then:
+                 */
+                assertThat(actual).isEqualTo(testCase.expected)
+            }
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/DescriptionTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/DescriptionTest.kt
@@ -1,0 +1,72 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+import arrow.core.leftNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+
+class DescriptionTest {
+    class New {
+        @Property
+        fun `正常系-長さが有効な場合、検証済の作成済記事の Description が戻り値`(
+            @ForAll @From(supplier = DescriptionValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Description.new(validString)
+
+            /**
+             * then:
+             */
+            val expected = Description.newWithoutValidation(validString)
+            when (actual) {
+                is Either.Left -> assert(false) { "原因: ${actual.value}" }
+                is Either.Right -> assertThat(actual.value.value).isEqualTo(expected.value)
+            }
+        }
+
+        @Property
+        fun `異常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @StringLength(min = 65) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 64
+
+            /**
+             * when:
+             */
+            val actual = Description.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Description.CreationError.TooLong(maximumLength).leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    /**
+     * Description の有効な範囲の String プロパティ
+     *
+     */
+    class DescriptionValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries
+                .strings()
+                .ofMinLength(0)
+                .ofMaxLength(64)
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/SlugTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/SlugTest.kt
@@ -1,0 +1,96 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+import arrow.core.leftNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SlugTest {
+    class New {
+        @Property
+        fun `正常系-文字列が有効な場合、検証済の Slug が戻り値`(
+            @ForAll @From(supplier = SlugValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Slug.new(validString)
+
+            /**
+             * then:
+             */
+            val expectedSlug = Slug.newWithoutValidation(validString)
+            when (actual) {
+                is Either.Left -> assert(false) { "原因: ${actual.value}" }
+                is Either.Right -> assertThat(actual.value.value).isEqualTo(expectedSlug.value)
+            }
+        }
+
+        @Property
+        fun `異常系-文字列が有効でない場合、バリデーションエラーが戻り値`(
+            @ForAll @From(supplier = SlugInvalidRange::class) invalidString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Slug.new(invalidString)
+
+            /**
+             * then:
+             */
+            val expected = Slug.CreationError.ValidFormat(invalidString).leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `正常系-new() で生成される文字列は 32 文字の英数字`() {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Slug.new().value
+
+            /**
+             * then:
+             */
+            val expectedPattern = "^[a-z0-9]{32}$"
+            assertThat(actual).matches(expectedPattern)
+        }
+    }
+    /**
+     * Slug の有効な範囲の String プロパティ
+     */
+    class SlugValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .numeric()
+                .withCharRange('a', 'z')
+                .ofLength(32)
+    }
+
+    /**
+     * Slug の無効な範囲の String プロパティ
+     */
+    class SlugInvalidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> =
+            Arbitraries.strings()
+                .filter { !it.matches(Regex("^[a-z0-9]{32}$")) }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/TitleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/domain/TitleTest.kt
@@ -1,0 +1,104 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+import arrow.core.leftNel
+import net.jqwik.api.Arbitraries
+import net.jqwik.api.Arbitrary
+import net.jqwik.api.ArbitrarySupplier
+import net.jqwik.api.ForAll
+import net.jqwik.api.From
+import net.jqwik.api.Property
+import net.jqwik.api.constraints.NotBlank
+import net.jqwik.api.constraints.StringLength
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TitleTest {
+    class New {
+        @Property
+        fun `正常系-長さが有効な場合、検証済の Title が戻り値`(
+            @ForAll @From(supplier = TitleValidRange::class) validString: String,
+        ) {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val actual = Title.new(validString)
+
+            /**
+             * then:
+             */
+            val expected = Title.newWithoutValidation(validString)
+            when (actual) {
+                is Either.Left -> assert(false) { "原因: ${actual.value}" }
+                is Either.Right -> assertThat(actual.value.value).isEqualTo(expected.value)
+            }
+        }
+
+        @Property
+        fun `異常系-長さが長すぎる場合、バリデーションエラーが戻り値`(
+            @ForAll @NotBlank @StringLength(min = 33) tooLongString: String,
+        ) {
+            /**
+             * given:
+             */
+            val maximumLength = 32
+
+            /**
+             * when:
+             */
+            val actual = Title.new(tooLongString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.TooLong(maximumLength).leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `異常系-空文字列の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val emptyString = ""
+
+            /**
+             * when:
+             */
+            val actual = Title.new(emptyString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.Required.leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+
+        @Test
+        fun `異常系-空白の場合、バリデーションエラーが戻り値`() {
+            /**
+             * given:
+             */
+            val blankString = "  "
+
+            /**
+             * when:
+             */
+            val actual = Title.new(blankString)
+
+            /**
+             * then:
+             */
+            val expected = Title.CreationError.Required.leftNel()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    class TitleValidRange : ArbitrarySupplier<String> {
+        override fun get(): Arbitrary<String> = Arbitraries.strings().ofMinLength(1).ofMaxLength(32).filter { it.isNotBlank() }
+    }
+}


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.3 ドメインオブジェクトの実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- domain package の実装で Validated 型から EitherNel 型に移行し、それに伴い実装を更新
- presentation 層の更新により、null 許容型は引数にならない想定で実装


以下でミスがあったので再作成。

https://github.com/Msksgm/hands-on-server-side-kotlin/pull/68
