### PR TITLE
feat: 「📃3.4 記事単一取得 API の実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/build.gradle.kts
+++ b/chapter-03/implementing-server-side-kotlin-development/build.gradle.kts
@@ -243,3 +243,9 @@ detekt {
 		"$projectDir/config/detekt/detekt-override.yml",
 	)
 }
+
+openApi {
+	apiDocsUrl.set("http://localhost:8080/v3/api-docs.yaml")
+	outputDir.set(project.layout.buildDirectory.dir("springdoc"))
+	outputFileName.set("openapi.yaml")
+}

--- a/chapter-03/implementing-server-side-kotlin-development/config/detekt/detekt-override.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/config/detekt/detekt-override.yml
@@ -46,7 +46,7 @@ style:
   MaxLineLength:
     active: true
     excludes: ['**/test/**'] # (default: なし）
-    maxLineLength: 120
+    maxLineLength: 220 #（default: 120） SpringBoot と SpringDoc のアノテーションによって、超過しやすいので緩めに設定
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false
@@ -58,7 +58,8 @@ style:
   ReturnCount:
     active: true
     max: 4 # (default: 2)
-    excludedFunctions: 'equals'
+    excludedFunctions:
+      - 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true
     excludeGuardClauses: false
@@ -78,6 +79,14 @@ formatting:
   active: true
   android: false
   autoCorrect: true
+  TrailingCommaOnCallSite:
+    active: true
+    autoCorrect: true
+    useTrailingCommaOnCallSite: true
+  TrailingCommaOnDeclarationSite:
+    active: true
+    autoCorrect: true
+    useTrailingCommaOnDeclarationSite: true
   #
   # MaximumLineLength
   # 概要
@@ -88,7 +97,7 @@ formatting:
   MaximumLineLength:
     active: true
     excludes: ['**/test/**'] # (default: なし）
-    maxLineLength: 120
+    maxLineLength: 220 #（default: 120） SpringBoot と SpringDoc のアノテーションによって、超過しやすいので緩めに設定
     ignoreBackTickedIdentifier: false
 
 # 潜在的なバグの検出

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/ImplementingServerSideKotlinDevelopmentApplication.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/ImplementingServerSideKotlinDevelopmentApplication.kt
@@ -1,5 +1,8 @@
 package com.example.implementingserversidekotlindevelopment
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.servers.Server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
@@ -8,6 +11,19 @@ import org.springframework.boot.runApplication
  *
  */
 @SpringBootApplication
+@OpenAPIDefinition(
+    info = Info(
+        title = "Implementing Server Side Kotlin",
+        version = "0.0",
+        description = "Sample API of Hands On Server Side Kotlin",
+    ),
+    servers = [
+        Server(
+            description = "Local Server",
+            url = "http://localhost:8080",
+        ),
+    ],
+)
 class ImplementingServerSideKotlinDevelopmentApplication
 
 /**

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -1,0 +1,30 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.Either
+
+/**
+ * 作成済記事リポジトリ
+ *
+ */
+interface ArticleRepository {
+    /**
+     * slug から作成済記事を取得
+     *
+     * @param slug
+     * @return
+     */
+    fun findBySlug(slug: Slug): Either<FindBySlugError, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 作成済記事取得時のエラー
+     *
+     */
+    sealed interface FindBySlugError {
+        /**
+         * slug に該当する記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFound(val slug: Slug) : FindBySlugError
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.example.implementingserversidekotlindevelopment.infra
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
+import com.example.implementingserversidekotlindevelopment.domain.Body
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Description
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.Title
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+
+/**
+ * 作成済記事リポジトリの具象クラス
+ *
+ * @property namedParameterJdbcTemplate
+ */
+@Repository
+class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTemplate) : ArticleRepository {
+    override fun findBySlug(slug: Slug): Either<ArticleRepository.FindBySlugError, CreatedArticle> {
+        val sql = """
+            SELECT
+                articles.slug
+                , articles.title
+                , articles.body
+                , articles.description
+            FROM
+                articles
+            WHERE
+                slug = :slug
+        """.trimIndent()
+        val articleMapList = namedParameterJdbcTemplate.queryForList(sql, MapSqlParameterSource().addValue("slug", slug.value))
+
+        /**
+         * DB から作成済記事が見つからなかった場合、早期 return
+         */
+        if (articleMapList.isEmpty()) {
+            return ArticleRepository.FindBySlugError.NotFound(slug = slug).left()
+        }
+
+        val articleMap = articleMapList.first()
+
+        return CreatedArticle.newWithoutValidation(
+            slug = Slug.newWithoutValidation(articleMap["slug"].toString()),
+            title = Title.newWithoutValidation(articleMap["title"].toString()),
+            description = Description.newWithoutValidation(articleMap["description"].toString()),
+            body = Body.newWithoutValidation(articleMap["body"].toString()),
+        ).right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
@@ -1,0 +1,160 @@
+package com.example.implementingserversidekotlindevelopment.presentation
+
+import arrow.core.getOrElse
+import com.example.implementingserversidekotlindevelopment.presentation.model.Article
+import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModel
+import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModelErrors
+import com.example.implementingserversidekotlindevelopment.presentation.model.SingleArticleResponse
+import com.example.implementingserversidekotlindevelopment.usecase.ShowArticleUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.hibernate.validator.constraints.Length
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 作成済記事記事のコントローラー
+ *
+ * @property showArticleUseCase 単一記事取得ユースケース
+ */
+@RestController
+@Validated
+class ArticleController(val showArticleUseCase: ShowArticleUseCase) {
+    /**
+     * 単一の作成済記事取得
+     *
+     * @return
+     */
+    @Operation(
+        summary = "単一記事取得",
+        operationId = "getArticle",
+        description = "slug に一致する記事を取得します。",
+        tags = ["articles"],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "OK",
+                content = [
+                    Content(
+                        schema = Schema(implementation = SingleArticleResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "OK",
+                                value = """
+                                    {
+                                        "article": {
+                                            "slug": "283e60096c26aa3a39cf04712cdd1ff7",
+                                            "title": "title",
+                                            "description": "description",
+                                            "body": "body"
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Not Found",
+                content = [
+                    Content(
+                        schema = Schema(implementation = GenericErrorModel::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Not Found",
+                                value = """
+                                    {
+                                        "errors": {
+                                            "body": [
+                                                "slug に該当する記事は見つかりませんでした"
+                                            ]
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @GetMapping("/api/articles/{slug}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getArticle(
+        @Parameter(description = "記事の slug", required = true, schema = Schema(minLength = 32, maxLength = 32)) @Valid @PathVariable("slug") @Length(min = 32, max = 32) slug: String,
+    ): ResponseEntity<SingleArticleResponse> {
+        /**
+         * 作成済記事の取得
+         */
+        val createdArticle = showArticleUseCase.execute(slug).getOrElse { throw ShowArticleUseCaseErrorException(it) }
+
+        return ResponseEntity(
+            SingleArticleResponse(
+                article = Article(
+                    slug = createdArticle.slug.value,
+                    title = createdArticle.title.value,
+                    description = createdArticle.description.value,
+                    body = createdArticle.body.value,
+                ),
+            ),
+            HttpStatus.OK
+        )
+    }
+
+    /**
+     * 単一記事取得ユースケースがエラーを戻したときの Exception
+     *
+     * このクラスの例外が発生したときに、@ExceptionHandler で例外処理をおこなう
+     *
+     * @property error
+     */
+    data class ShowArticleUseCaseErrorException(val error: ShowArticleUseCase.Error) : Exception()
+
+    /**
+     * ShowArticleUseCaseErrorException をハンドリングする関数
+     *
+     * ShowArticleUseCase.Error の型に合わせてレスポンスを分岐させる
+     *
+     * @param e
+     * @return
+     */
+    @ExceptionHandler(value = [ShowArticleUseCaseErrorException::class])
+    fun onShowArticleUseCaseErrorException(e: ShowArticleUseCaseErrorException): ResponseEntity<GenericErrorModel> =
+        when (val error = e.error) {
+            /**
+             * 原因: slug に該当する記事が見つからなかった
+             */
+            is ShowArticleUseCase.Error.NotFoundArticleBySlug -> ResponseEntity<GenericErrorModel>(
+                GenericErrorModel(
+                    errors = GenericErrorModelErrors(
+                        body = listOf("${error.slug.value} に該当する記事は見つかりませんでした")
+                    )
+                ),
+                HttpStatus.NOT_FOUND
+            )
+
+            /**
+             * 原因: バリデーションエラー
+             */
+            is ShowArticleUseCase.Error.ValidationErrors -> ResponseEntity<GenericErrorModel>(
+                GenericErrorModel(
+                    errors = GenericErrorModelErrors(
+                        body = error.errors.map { it.message }
+                    )
+                ),
+                HttpStatus.BAD_REQUEST
+            )
+        }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/GlobalExceptionHandleController.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/GlobalExceptionHandleController.kt
@@ -1,0 +1,172 @@
+package com.example.implementingserversidekotlindevelopment.presentation
+
+import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModel
+import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModelErrors
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.FieldError
+import org.springframework.web.HttpMediaTypeNotSupportedException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import java.util.Locale
+
+/**
+ * グローバルに例外ハンドリグし、エラーレスポンスを実現するコントローラ
+ *
+ * 予期しない例外が発生した際に、以下を実施する。
+ * - 秘密情報をレスポンスに含めないためのエラーハンドリング
+ * - 原因調査のためのログ出力
+ *
+ */
+@RestControllerAdvice
+class GlobalExceptionHandleController {
+    /**
+     * 存在しないエンドポイントにリクエストされた時のエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 404 エラーのレスポンス
+     */
+    @ExceptionHandler(NoResourceFoundException::class)
+    @Suppress("UnusedParameter") // NoResourceFoundException は理由が明確なので、e を使わずに linter を抑制する
+    fun noResourceFoundExceptionHandler(e: NoResourceFoundException): ResponseEntity<GenericErrorModel> {
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = listOf("該当するエンドポイントがありませんでした")
+                ),
+            ),
+            HttpStatus.NOT_FOUND
+        )
+    }
+
+    /**
+     * 許可されていないメソッドでリクエストを送った時のエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 405 エラーのレスポンス
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun noHttpRequestMethodNotSupportedExceptionHandler(
+        e: HttpRequestMethodNotSupportedException
+    ): ResponseEntity<GenericErrorModel> {
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = listOf("該当エンドポイントで${e.method}メソッドの処理は許可されていません")
+                ),
+            ),
+            HttpStatus.METHOD_NOT_ALLOWED
+        )
+    }
+
+    /**
+     * エンドポイントが想定していない Content-Type でリクエストされた時にエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 415 エラーのレスポンス
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+    fun noHttpMediaTypeNotSupportedException(
+        e: HttpMediaTypeNotSupportedException
+    ): ResponseEntity<GenericErrorModel> {
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = listOf("該当エンドポイントで${e.contentType}のリクエストはサポートされていません")
+                ),
+            ),
+            HttpStatus.UNSUPPORTED_MEDIA_TYPE
+        )
+    }
+
+    /**
+     * httpMessageNotReadableExceptionHandler
+     *
+     * API スキーマが想定していないリクエストだった場合に発生させるエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 400 エラーのレスポンス
+     */
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    @Suppress("UnusedParameter")
+    fun httpMessageNotReadableExceptionHandler(e: HttpMessageNotReadableException): ResponseEntity<GenericErrorModel> {
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = listOf("エンドポイントが想定していない形式または型のリクエストが送られました")
+                ),
+            ),
+            HttpStatus.BAD_REQUEST
+        )
+    }
+
+    /**
+     * リクエストのバリデーションエラーが発生した場合に発生させるエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 400 エラーのレスポンス
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun methodArgumentNotValidExceptionHandler(e: MethodArgumentNotValidException): ResponseEntity<GenericErrorModel> {
+        // エラーメッセージ本文の作成。FieldError の場合は、フィールド名を含める
+        val messages = e.bindingResult.allErrors.map {
+            when (it) {
+                is FieldError -> "${it.field}は${it.defaultMessage}"
+                else -> it.defaultMessage.toString()
+            }
+        }
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = messages
+                ),
+            ),
+            HttpStatus.BAD_REQUEST
+        )
+    }
+
+    /**
+     * パスパラメータまたはクエリパラメータのバリデーションエラーが発生した場合に発生させるエラーレスポンスを作成するメソッド
+     *
+     * @param e
+     * @return 400 エラーのレスポンス
+     */
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun constraintViolationExceptionExceptionHandler(e: ConstraintViolationException): ResponseEntity<GenericErrorModel> {
+        // ConstraintViolationException からレスポンスに利用するエラーメッセージを生成する
+        val messages = e.constraintViolations.map {
+            /**
+             * クエリパラメータをチェインケースに変換
+             *
+             * propertyPath は `@PathVariable` アノテーションで指定したパスパラメータではなく、メソッドの引数に指定したパラメータ名を取得する
+             * 例えば、以下のようなコントローラメソッドの場合、propertyPath が取得するのは、`page-number` ではなく `getArticle.pageNumber` になる
+             *
+             * ```kotlin
+             * fun getArticle(@RequestParam("page-number") @Max(20) pageNumber: String): ResponseEntity<Any>
+             * ```
+             *
+             * API 仕様書と一致しなくなる可能性があるため、チェインケースに変換する。
+             * **API 仕様書におけるパスパラメータとクエリパラメータの命名規則は必ず統一**すること。
+             */
+            val chainCaseRequestParam = it.propertyPath.toString().split('.').last().split(Regex("(?=[A-Z])")).joinToString("-") { param ->
+                param.lowercase(
+                    Locale.getDefault()
+                )
+            }
+            "${chainCaseRequestParam}は${it.message}"
+        }
+        return ResponseEntity<GenericErrorModel>(
+            GenericErrorModel(
+                errors = GenericErrorModelErrors(
+                    body = messages
+                ),
+            ),
+            HttpStatus.BAD_REQUEST
+        )
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/Article.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/Article.kt
@@ -1,0 +1,26 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 単一記事のレスポンスモデル
+ *
+ * @property slug 記事の slug
+ * @property title 記事のタイトル
+ * @property description 記事の説明
+ * @property body 記事の本文
+ */
+data class Article(
+    @Schema(example = "283e60096c26aa3a39cf04712cdd1ff7", required = true, description = "記事の slug")
+    @field:JsonProperty("slug", required = true) val slug: String,
+
+    @Schema(example = "article-title", required = true, description = "記事のタイトル")
+    @field:JsonProperty("title", required = true) val title: String,
+
+    @Schema(example = "article-description", required = true, description = "記事の説明")
+    @field:JsonProperty("description", required = true) val description: String,
+
+    @Schema(example = "article-body", required = true, description = "記事の本文")
+    @field:JsonProperty("body", required = true) val body: String,
+)

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/GenericErrorModel.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/GenericErrorModel.kt
@@ -1,0 +1,18 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * エラーモデル
+ *
+ * エラーの内容レスポンスモデル
+ *
+ * @property errors
+ */
+data class GenericErrorModel(
+    @field:Valid
+    @Schema(required = true, description = "")
+    @field:JsonProperty("errors", required = true) val errors: GenericErrorModelErrors
+)

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/GenericErrorModelErrors.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/GenericErrorModelErrors.kt
@@ -1,0 +1,16 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * エラーモデル
+ *
+ * エラーレスポンスの詳細を List<String> 型で記述する
+ *
+ * @property body
+ */
+data class GenericErrorModelErrors(
+    @Schema(required = true, description = "")
+    @field:JsonProperty("body", required = true) val body: List<String>,
+)

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/SingleArticleResponse.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/SingleArticleResponse.kt
@@ -1,0 +1,16 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * 単一記事取得のレスポンス
+ *
+ * @property article 作成済み記事
+ */
+data class SingleArticleResponse(
+    @field:Valid
+    @Schema(required = true, description = "")
+    @field:JsonProperty("article", required = true) val article: Article
+)

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
@@ -1,0 +1,48 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import org.springframework.stereotype.Service
+
+/**
+ * 作成済記事の単一取得ユースケース
+ *
+ */
+interface ShowArticleUseCase {
+    /**
+     * 単一記事取得
+     *
+     * @param slug
+     * @return
+     */
+    fun execute(slug: String): Either<Error, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 単一記事取得のエラー
+     *
+     */
+    sealed interface Error {
+        /**
+         * バリデーションエラー
+         *
+         * @property errors
+         */
+        data class ValidationErrors(val errors: List<ValidationError>) : Error
+
+        /**
+         * slug から記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFoundArticleBySlug(val slug: Slug) : Error
+    }
+}
+
+/**
+ * 作成済記事の単一取得ユースケースの具象クラス
+ *
+ */
+@Service
+class ShowArticleUseCaseImpl : ShowArticleUseCase

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/ShowArticleUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
 import com.example.implementingserversidekotlindevelopment.domain.Slug
 import com.example.implementingserversidekotlindevelopment.util.ValidationError
@@ -43,6 +47,29 @@ interface ShowArticleUseCase {
 /**
  * 作成済記事の単一取得ユースケースの具象クラス
  *
+ * @property articleRepository
  */
 @Service
-class ShowArticleUseCaseImpl : ShowArticleUseCase
+class ShowArticleUseCaseImpl(val articleRepository: ArticleRepository) : ShowArticleUseCase {
+    override fun execute(slug: String): Either<ShowArticleUseCase.Error, CreatedArticle> {
+        /**
+         * slug の検証
+         *
+         * 不正な slug だった場合、早期 return
+         */
+        val validatedSlug = Slug.new(slug).getOrElse { return ShowArticleUseCase.Error.ValidationErrors(it.all).left() }
+
+        /**
+         * 記事の取得
+         *
+         * 取得失敗した場合、早期 return
+         */
+        val createdArticle = articleRepository.findBySlug(validatedSlug).getOrElse {
+            return when (it) {
+                is ArticleRepository.FindBySlugError.NotFound -> ShowArticleUseCase.Error.NotFoundArticleBySlug(it.slug).left()
+            }
+        }
+
+        return createdArticle.right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/resources/ValidationMessages.properties
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,7 @@
+jakarta.validation.constraints.NotBlank.message=\u5FC5\u9808\u3067\u3059
+jakarta.validation.constraints.NotNull.message=null\u304C\u8A31\u53EF\u3055\u308C\u3066\u3044\u307E\u305B\u3093
+jakarta.validation.constraints.Size.message={min}\u6587\u5B57\u4EE5\u4E0A{max}\u6587\u5B57\u4EE5\u4E0B\u306B\u3057\u3066\u304F\u3060\u3055\u3044
+jakarta.validation.constraints.Max.message={value}\u4EE5\u4E0B\u306B\u3057\u3066\u304F\u3060\u3055\u3044
+jakarta.validation.constraints.Min.message={value}\u4EE5\u4E0A\u306B\u3057\u3066\u304F\u3060\u3055\u3044
+
+org.hibernate.validator.constraints.Length.message={min}\u6587\u5B57\u4EE5\u4E0A{max}\u6587\u5B57\u4EE5\u4E0B\u306B\u3057\u3066\u304F\u3060\u3055\u3044

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/resources/application.properties
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/resources/application.properties
@@ -5,3 +5,8 @@ spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/sample-db
 spring.datasource.username=sample-user
 spring.datasource.password=sample-pass
 spring.datasource.driver-class-name=org.postgresql.Driver
+
+#
+# springdoc
+#
+springdoc.swagger-ui.showCommonExtensions=true

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/resources/datasets/yml/given/articles.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/resources/datasets/yml/given/articles.yml
@@ -1,0 +1,11 @@
+articles:
+  - id: 1
+    title: "dummy-title-01"
+    slug: "slug0000000000000000000000000001"
+    body: "dummy-body-01"
+    description: "dummy-description-01"
+  - id: 2
+    title: "dummy-title-02"
+    slug: "slug0000000000000000000000000002"
+    body: "dummy-body-02"
+    description: "dummy-description-02"

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/resources/datasets/yml/given/empty-articles.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/resources/datasets/yml/given/empty-articles.yml
@@ -1,0 +1,1 @@
+articles:

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -1,0 +1,207 @@
+package com.example.implementingserversidekotlindevelopment.api.integration
+
+import com.example.implementingserversidekotlindevelopment.api.integration.helper.DbConnection
+import com.github.database.rider.core.api.dataset.DataSet
+import com.github.database.rider.junit5.api.DBRider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.skyscreamer.jsonassert.JSONAssert
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+class ArticleTest {
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class GetArticle(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        fun `正常系-slug に該当する作成済記事を取得する`() {
+            /**
+             * given:
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.OK.value()
+            val expectedResponseBody = """
+                {
+                  "article": {
+                    "slug": "slug0000000000000000000000000001",
+                    "title": "dummy-title-01",
+                    "description": "dummy-description-01",
+                    "body": "dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.STRICT
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-slug に該当する作成済記事が存在しない場合、該当する記事が見つからないエラー`() {
+            /**
+             * given:
+             * - DB に存在しない作成済記事
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.NOT_FOUND.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug0000000000000000000000000001 に該当する記事は見つかりませんでした"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-slug のフォーマットが不正な場合、バリデーションエラー`() {
+            /**
+             * given:
+             * - DB に存在しない作成済記事
+             */
+            val slug = "SLUG0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug は 32 文字の英小文字数字です。"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+
+
+        @Test
+        fun `異常系-slug が 32 文字でない場合、バリデーションエラー`() {
+            /**
+             * given:
+             * - 不正なフォーマットの slug
+             */
+            val slug = "dummy-slug"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slugは32文字以上32文字以下にしてください"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/CustomizedMockMvc.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/CustomizedMockMvc.kt
@@ -1,0 +1,19 @@
+package com.example.implementingserversidekotlindevelopment.api.integration.helper
+
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer
+import org.springframework.stereotype.Component
+import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder
+
+/**
+ * MockMvc のカスタマイズ
+ *
+ * Response の Content-Type に"charset=UTF-8"を付与
+ * 理由
+ * - デフォルトだと日本語が文字化けするため
+ */
+@Component
+class CustomizedMockMvc : MockMvcBuilderCustomizer {
+    override fun customize(builder: ConfigurableMockMvcBuilder<*>?) {
+        builder?.alwaysDo { result -> result.response.characterEncoding = "UTF-8" }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/DbConnection.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/helper/DbConnection.kt
@@ -1,0 +1,52 @@
+package com.example.implementingserversidekotlindevelopment.api.integration.helper
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import javax.sql.DataSource
+
+/**
+ * Db connection
+ *
+ * DB 統合テストで DB 設定をおこなうメソッド
+ *
+ * @constructor Create empty Db connection
+ */
+object DbConnection {
+    /**
+     * テスト時に DB 設定をするメソッド
+     *
+     * @return
+     */
+    fun dataSource(): DataSource {
+        val hikariConfig = HikariConfig()
+        hikariConfig.jdbcUrl = "jdbc:postgresql://127.0.0.1:5432/sample-db"
+        hikariConfig.username = "sample-user"
+        hikariConfig.password = "sample-pass"
+        hikariConfig.connectionTimeout = java.lang.Long.valueOf(500)
+        hikariConfig.isAutoCommit = true
+        hikariConfig.transactionIsolation = "TRANSACTION_READ_COMMITTED"
+        hikariConfig.poolName = "realworldPool01"
+        hikariConfig.maximumPoolSize = 10
+        return HikariDataSource(hikariConfig)
+    }
+
+    /**
+     * テスト時にテーブルのシーケンスを設定するメソッド
+     *
+     * 全てのテスト実行前に呼び出すことで、該当カラムの初期値が固定される
+     *
+     */
+    fun resetSequence() {
+        val namedParameterJdbcTemplate = NamedParameterJdbcTemplate(dataSource())
+        val sequenceValue = 10000
+        val sql = """
+            SELECT
+                setval('articles_id_seq', $sequenceValue)
+            ;
+        """.trimIndent()
+        // シーケンスをリセット
+        namedParameterJdbcTemplate.queryForList(sql, MapSqlParameterSource())
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/resources/dbunit.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/resources/dbunit.yml
@@ -1,0 +1,125 @@
+#
+# dbunit.yml
+#
+# 参考
+# - 大元
+#   - https://database-rider.github.io/database-rider/
+# - 1.32.3版のドキュメント
+#   - https://database-rider.github.io/database-rider/1.32.3/documentation.html#_dbunit_configuration
+# - サンプル
+#   - https://github.com/database-rider/database-rider/blob/master/rider-core/src/test/resources/config/sample-dbunit.yml
+#   - https://github.com/database-rider/database-rider#332-dbunit-configuration:
+#     - 説明付き
+#
+# 注: @DBUnitの方が優先される
+#
+
+#
+# cacheConnection
+# true: テスト間でコネクションが再利用される
+# default: true
+#
+cacheConnection: true
+
+#
+# cacheTableNames
+# true: テーブル名をキャッシュし、不必要なメタデータ接続を回避
+# default: true
+#
+cacheTableNames: true
+
+#
+# leakHunter
+# true: 接続リーク検出を有効化（テスト後にオープン状態のJDBC接続があれば検知）
+# default: false
+#
+leakHunter: false
+
+#
+# alwaysCleanBefore
+# true: @DataSet(cleanBefore)のデフォルトをtrueにする
+# default: false
+#
+alwaysCleanBefore: true
+
+#
+# alwaysCleanAfter
+# true: @DataSet(cleanAfter)のデフォルトをtrueにする
+# default: false
+#
+alwaysCleanAfter: false
+
+#
+# raiseExceptionOnCleanUp
+# true: cleanBefore/cleanAfterでcleanしようとしたら、例外を投げる
+# default: false
+#
+raiseExceptionOnCleanUp: true
+
+properties:
+  #
+  # properties.schema
+  # default: null
+  schema: public
+
+  #
+  # properties.batchedStatements
+  #
+  # true：JDBCバッチステートメントを使用できる
+  # default: false
+  #
+  batchedStatements:  false
+
+  #
+  # properties.qualifiedTableNames
+  # true：DBUnitはSCHEMA.TABLEで完全修飾された名前のテーブルにアクセスする
+  # false：複数のスキーマサポートを無効化
+  # default: false
+  #
+  qualifiedTableNames: false
+
+  #
+  # properties.caseSensitiveTableNames
+  # true：テーブル名の大文字・小文字を区別する
+  # default: false
+  #
+  caseSensitiveTableNames: true
+
+  #
+  # properties.batchSize
+  # 数値：JDBC一括更新のサイズ指定
+  # default: 100
+  #
+  batchSize: 100
+
+  #
+  # properties.fetchSize
+  # 数値：結果セットテーブルにデータをロードするためのfetchサイズの指定
+  # default: 100
+  #
+  fetchSize: 100
+
+  #
+  # properties.allowEmptyFields
+  # true：空文字でINSERT/UPDATEをcallできるようにする
+  # default: false
+  #
+  allowEmptyFields: true
+
+  #
+  # properties.escapePattern
+  # default: {}
+  #
+  #escapePattern:
+
+#
+# connectionConfig
+# JDBC接続設定
+# Entity Managerが接続をしてくれるなら別
+# default: 全て""
+#
+connectionConfig:
+  driver: "org.postgresql.Driver"
+  url: "jdbc:postgresql://127.0.0.1:5432/sample-db"
+  user: "sample-user"
+  password: "sample-pass"


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.4 記事単一取得 API の実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- OpenAPI Generator から SpringDoc を利用した実装に変更
- infra 層のテストを削除

以下の PR でマージしたが、ミスを発見したので、作成し直し。

https://github.com/Msksgm/hands-on-server-side-kotlin/pull/70

