### PR TITLE
feat: 「📃3.5 記事作成 API の実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -27,4 +27,18 @@ interface ArticleRepository {
          */
         data class NotFound(val slug: Slug) : FindBySlugError
     }
+
+    /**
+     * 作成済記事を保存
+     *
+     * @param createdArticle
+     * @return
+     */
+    fun create(createdArticle: CreatedArticle): Either<CreateArticleError, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 作成済記事を保存したときのエラー
+     *
+     */
+    sealed interface CreateArticleError
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -50,4 +50,30 @@ class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTe
             body = Body.newWithoutValidation(articleMap["body"].toString()),
         ).right()
     }
+
+    override fun create(createdArticle: CreatedArticle): Either<ArticleRepository.CreateArticleError, CreatedArticle> {
+        val sql = """
+            INSERT INTO articles (
+                slug
+                , title
+                , body
+                , description
+            )
+            VALUES (
+                :slug
+                , :title
+                , :body
+                , :description
+            )
+        """.trimIndent()
+        namedParameterJdbcTemplate.update(
+            sql,
+            MapSqlParameterSource()
+                .addValue("slug", createdArticle.slug.value)
+                .addValue("title", createdArticle.title.value)
+                .addValue("body", createdArticle.body.value)
+                .addValue("description", createdArticle.description.value)
+        )
+        return createdArticle.right()
+    }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/ArticleController.kt
@@ -4,7 +4,9 @@ import arrow.core.getOrElse
 import com.example.implementingserversidekotlindevelopment.presentation.model.Article
 import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModel
 import com.example.implementingserversidekotlindevelopment.presentation.model.GenericErrorModelErrors
+import com.example.implementingserversidekotlindevelopment.presentation.model.NewArticleRequest
 import com.example.implementingserversidekotlindevelopment.presentation.model.SingleArticleResponse
+import com.example.implementingserversidekotlindevelopment.usecase.CreateArticleUseCase
 import com.example.implementingserversidekotlindevelopment.usecase.ShowArticleUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -21,16 +23,22 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 /**
  * 作成済記事記事のコントローラー
  *
  * @property showArticleUseCase 単一記事取得ユースケース
+ * @property createArticleUseCase 記事作成ユースケース
  */
 @RestController
 @Validated
-class ArticleController(val showArticleUseCase: ShowArticleUseCase) {
+class ArticleController(
+    val showArticleUseCase: ShowArticleUseCase,
+    val createArticleUseCase: CreateArticleUseCase,
+) {
     /**
      * 単一の作成済記事取得
      *
@@ -155,6 +163,122 @@ class ArticleController(val showArticleUseCase: ShowArticleUseCase) {
                     )
                 ),
                 HttpStatus.BAD_REQUEST
+            )
+        }
+
+    /**
+     * 新規記事作成
+     *
+     * @return
+     */
+    @Operation(
+        summary = "新規記事作成",
+        operationId = "CreateArticle",
+        description = "新規に記事を作成します",
+        tags = ["articles"],
+        responses = [
+            ApiResponse(
+                responseCode = "201",
+                description = "OK",
+                content = [
+                    Content(
+                        schema = Schema(implementation = SingleArticleResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "OK",
+                                value = """
+                                    {
+                                        "article": {
+                                            "slug": "283e60096c26aa3a39cf04712cdd1ff7",
+                                            "title": "new-article-title",
+                                            "description": "new-article-description",
+                                            "body": "new-article-body"
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Validation Error",
+                content = [
+                    Content(
+                        schema = Schema(implementation = GenericErrorModel::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Validation Error",
+                                value = """
+                                    {
+                                        "errors": {
+                                            "body": [
+                                                "article.titleは必須です",
+                                                "article.bodyは0文字以上64文字以下です",
+                                                "article.descriptionは0文字以上1024文字以下です"
+                                            ]
+                                        }
+                                    }
+                                """
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+    @PostMapping("/api/articles", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun createArticle(@Valid @RequestBody newArticleRequest: NewArticleRequest): ResponseEntity<SingleArticleResponse> {
+        val createdArticle = createArticleUseCase.execute(
+            title = newArticleRequest.validatedArticle.validatedTitle,
+            description = newArticleRequest.validatedArticle.validatedDescription,
+            body = newArticleRequest.validatedArticle.validatedBody,
+        ).getOrElse { throw CreateArticleUseCaseErrorException(it) }
+
+        return ResponseEntity(
+            SingleArticleResponse(
+                article = Article(
+                    slug = createdArticle.slug.value,
+                    title = createdArticle.title.value,
+                    description = createdArticle.description.value,
+                    body = createdArticle.body.value,
+                ),
+            ),
+            HttpStatus.CREATED
+        )
+    }
+
+    /**
+     * 記事作成ユースケースがエラーを戻したときの Exception
+     *
+     * このクラスの例外が発生したときに、@ExceptionHandler で例外をおこなう
+     *
+     * @property error
+     */
+    data class CreateArticleUseCaseErrorException(val error: CreateArticleUseCase.Error) : Throwable()
+
+    /**
+     * CreateArticleUseCaseErrorException をハンドリングする関数
+     *
+     * CreateArticleUseCase.Error の型に合わせてレスポンスを分岐する
+     *
+     * @param e
+     * @return
+     */
+    @ExceptionHandler(value = [CreateArticleUseCaseErrorException::class])
+    fun onCreateArticleUseCaseErrorException(e: CreateArticleUseCaseErrorException): ResponseEntity<GenericErrorModel> =
+        when (val error = e.error) {
+            /**
+             * 原因: 記事のリクエストが不正
+             */
+            is CreateArticleUseCase.Error.InvalidArticle -> ResponseEntity<GenericErrorModel>(
+                GenericErrorModel(
+                    errors = GenericErrorModelErrors(
+                        body = error.errors.map { it.message }
+                    )
+                ),
+                HttpStatus.FORBIDDEN
             )
         }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/NewArticle.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/NewArticle.kt
@@ -1,0 +1,68 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.hibernate.validator.constraints.Length
+
+/**
+ * 新規作成記事
+ *
+ * @param title 新規作成記事のタイトル
+ * @param description 新規作成記事の説明
+ * @param body 新規作成記事の本文
+ */
+data class NewArticle(
+    @Schema(example = "new-article-title", required = true, description = "新規作成記事のタイトル")
+    @field:Valid
+    @field:NotBlank
+    @field:Length(min = 0, max = 32)
+    @field:JsonProperty("title", required = true) private val title: String? = null,
+
+    @Schema(example = "new-article-description", required = true, description = "新規作成記事の説明")
+    @field:Valid
+    @field:NotNull
+    @field:Length(min = 0, max = 64)
+    @field:JsonProperty("description", required = true) private val description: String? = null,
+
+    @Schema(example = "new-article-body", required = true, description = "新規作成記事の本文")
+    @field:Valid
+    @field:NotNull
+    @field:Length(min = 0, max = 1024)
+    @field:JsonProperty("body", required = true) private val body: String? = null,
+) {
+    /**
+     * 新規作成記事のタイトル
+     *
+     * @NotBlank アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedTitle: String
+        get() = title!!
+
+    /**
+     * 新規作成記事の説明
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedDescription: String
+        get() = description!!
+
+    /**
+     * 新規作成記事の本文
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedBody: String
+        get() = body!!
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/NewArticleRequest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/NewArticleRequest.kt
@@ -1,0 +1,27 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 新規作成のリクエストモデル
+ *
+ * @param article
+ */
+data class NewArticleRequest(
+    @field:Valid
+    @Schema(required = true, description = "")
+    @field:NotNull
+    @field:JsonProperty("article", required = true) private val article: NewArticle? = null,
+) {
+    /**
+     * 新規作成記事のプロパティ
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     */
+    @get:Schema(hidden = true)
+    val validatedArticle: NewArticle
+        get() = article!!
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/CreateArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/CreateArticleUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
 import com.example.implementingserversidekotlindevelopment.util.ValidationError
 import org.springframework.stereotype.Service
@@ -37,6 +41,23 @@ interface CreateArticleUseCase {
 /**
  * 作成済記事の作成ユースケース取得クラス
  *
+ * @property articleRepository
  */
 @Service
-class CreateArticleUseCaseImpl : CreateArticleUseCase
+class CreateArticleUseCaseImpl(val articleRepository: ArticleRepository) : CreateArticleUseCase {
+    override fun execute(title: String, description: String, body: String): Either<CreateArticleUseCase.Error, CreatedArticle> {
+        /**
+         * 作成済記事オブジェクトの作成
+         *
+         * バリデーションエラーが発生した場合、早期リターン
+         */
+        val uncreatedArticle = CreatedArticle.new(title, description, body).getOrElse { return CreateArticleUseCase.Error.InvalidArticle(it).left() }
+
+        /**
+         * 作成済記事を保存
+         */
+        val createdArticle = articleRepository.create(createdArticle = uncreatedArticle).getOrElse { throw UnsupportedOperationException("現在この分岐に入ることはない") }
+
+        return createdArticle.right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/CreateArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/CreateArticleUseCase.kt
@@ -1,0 +1,42 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import org.springframework.stereotype.Service
+
+/**
+ * 記事作成ユースケース
+ *
+ */
+interface CreateArticleUseCase {
+    /**
+     * 記事作成
+     *
+     * @param title
+     * @param description
+     * @param body
+     * @return
+     */
+    fun execute(title: String, description: String, body: String): Either<Error, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 記事作成ユースケースのエラー
+     *
+     */
+    sealed interface Error {
+        /**
+         * 記事のリクエストが不正だった
+         *
+         * @property errors
+         */
+        data class InvalidArticle(val errors: List<ValidationError>) : Error
+    }
+}
+
+/**
+ * 作成済記事の作成ユースケース取得クラス
+ *
+ */
+@Service
+class CreateArticleUseCaseImpl : CreateArticleUseCase

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/resources/ValidationMessages.properties
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/resources/ValidationMessages.properties
@@ -1,5 +1,5 @@
 jakarta.validation.constraints.NotBlank.message=\u5FC5\u9808\u3067\u3059
-jakarta.validation.constraints.NotNull.message=null\u304C\u8A31\u53EF\u3055\u308C\u3066\u3044\u307E\u305B\u3093
+jakarta.validation.constraints.NotNull.message=\u5FC5\u9808\u3067\u3059
 jakarta.validation.constraints.Size.message={min}\u6587\u5B57\u4EE5\u4E0A{max}\u6587\u5B57\u4EE5\u4E0B\u306B\u3057\u3066\u304F\u3060\u3055\u3044
 jakarta.validation.constraints.Max.message={value}\u4EE5\u4E0B\u306B\u3057\u3066\u304F\u3060\u3055\u3044
 jakarta.validation.constraints.Min.message={value}\u4EE5\u4E0A\u306B\u3057\u3066\u304F\u3060\u3055\u3044

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -2,13 +2,16 @@ package com.example.implementingserversidekotlindevelopment.api.integration
 
 import com.example.implementingserversidekotlindevelopment.api.integration.helper.DbConnection
 import com.github.database.rider.core.api.dataset.DataSet
+import com.github.database.rider.core.api.dataset.ExpectedDataSet
 import com.github.database.rider.junit5.api.DBRider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.skyscreamer.jsonassert.Customization
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+import org.skyscreamer.jsonassert.comparator.CustomComparator
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -16,6 +19,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 
 class ArticleTest {
     @SpringBootTest
@@ -163,7 +167,6 @@ class ArticleTest {
             )
         }
 
-
         @Test
         fun `異常系-slug が 32 文字でない場合、バリデーションエラー`() {
             /**
@@ -201,6 +204,86 @@ class ArticleTest {
                 expectedResponseBody,
                 actualResponseBody,
                 JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+    }
+
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class CreateArticle(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        @ExpectedDataSet(
+            value = ["datasets/yml/then/created-articles.yml"],
+            orderBy = ["id"],
+            ignoreCols = ["slug"]
+        )
+        // NOTE: @ExportDataSetはgivenの@DataSetが変更された時用に残しておく
+        // @ExportDataSet(
+        //     format = DataSetFormat.YML,
+        //     outputName = "src/test/resources/datasets/yml/then/created-articles.yml",
+        //     includeTables = ["articles"]
+        // )
+        fun `正常系-記事が作成される`() {
+            /**
+             * given:
+             */
+            val requestBody = """
+                {
+                  "article": {
+                    "title": "dummy-title-01",
+                    "description": "dummy-description-01",
+                    "body": "dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.post("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             * - JSON レスポンスを比較する。slug は自動生成されるので、形式だけ確認する
+             */
+            val expectedStatus = HttpStatus.CREATED.value()
+            val expectedResponseBody = """
+                {
+                  "article": {
+                    "slug": "slug0000000000000000000000000001",
+                    "title": "dummy-title-01",
+                    "description": "dummy-description-01",
+                    "body": "dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                CustomComparator(
+                    JSONCompareMode.STRICT,
+                    Customization("article.slug") { actualSlug, _ -> actualSlug.toString().matches(Regex("^[a-z0-9]{32}\$")) }
+                )
             )
         }
     }

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -286,5 +286,173 @@ class ArticleTest {
                 )
             )
         }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title、description、body がないときバリデーションエラー`() {
+            /**
+             * given:
+             * - title、description、body がない
+             */
+            val responseBody = """
+                {
+                  "article": {}
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.post("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.descriptionは必須です",
+                            "article.titleは必須です",
+                            "article.bodyは必須です"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title は必須`() {
+            /**
+             * given:
+             * - title が 空白
+             */
+            val title = ""
+            val responseBody = """
+                {
+                  "article": {
+                    "title": "$title",
+                    "description": "",
+                    "body": ""
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.post("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.titleは必須です"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title が 33 文字以上、description が 65 文字以上、body が 1025 文字以上`() {
+            /**
+             * given:
+             * - title が 32 文字超過
+             * - description が 64 文字超過
+             * - body が 1024 文字超過
+             */
+            val title = "a".repeat(33)
+            val description = "a".repeat(65)
+            val body = "a".repeat(1025)
+            val responseBody = """
+                {
+                  "article": {
+                    "title": "$title",
+                    "description": "$description",
+                    "body": "$body"
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.post("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.titleは0文字以上32文字以下にしてください",
+                            "article.bodyは0文字以上1024文字以下にしてください",
+                            "article.descriptionは0文字以上64文字以下にしてください"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
     }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/created-articles.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/created-articles.yml
@@ -1,0 +1,6 @@
+articles:
+  - id: 10001
+    title: "dummy-title-01"
+    slug: "slug0000000000000000000000000001"
+    body: "dummy-body-01"
+    description: "dummy-description-01"


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.4 記事単一取得 API の実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- OpenAPI Generator から SpringDoc を利用した実装に変更
- infra 層のテストを削除

以下の PR で対応したが、ミスを発見したので、作成しなおし。

- https://github.com/Msksgm/hands-on-server-side-kotlin/pull/75