### PR TITLE
feat: 「📃3.6 記事一覧取得 API の実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -41,4 +41,18 @@ interface ArticleRepository {
      *
      */
     sealed interface CreateArticleError
+
+    /**
+     * 作成済記事の一覧取得
+     *
+     * @return
+     */
+    fun all(): Either<FindError, List<CreatedArticle>> = throw NotImplementedError()
+
+    /**
+     * ArticleRepository.all のエラーインタフェース
+     *
+     * エラーになるパターンが存在しない
+     */
+    sealed interface FindError
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -76,4 +76,26 @@ class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTe
         )
         return createdArticle.right()
     }
+
+    override fun all(): Either<ArticleRepository.FindError, List<CreatedArticle>> {
+        val sql = """
+            SELECT
+                articles.slug
+                , articles.title
+                , articles.body
+                , articles.description
+            FROM
+                articles
+            ;
+        """.trimIndent()
+        val articleMap = namedParameterJdbcTemplate.queryForList(sql, MapSqlParameterSource())
+        return articleMap.map {
+            CreatedArticle.newWithoutValidation(
+                Slug.newWithoutValidation(it["slug"].toString()),
+                Title.newWithoutValidation(it["title"].toString()),
+                Description.newWithoutValidation(it["description"].toString()),
+                Body.newWithoutValidation(it["body"].toString())
+            )
+        }.right()
+    }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/MultipleArticleResponse.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/MultipleArticleResponse.kt
@@ -1,0 +1,20 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+
+/**
+ * 複数記事のレスポンスモデル
+ *
+ * @param articles
+ * @param articleCount
+ */
+data class MultipleArticleResponse(
+    @field:Valid
+    @Schema(required = true, description = "")
+    @field:JsonProperty("articles", required = true) val articles: List<Article>,
+
+    @Schema(example = "3", description = "")
+    @field:JsonProperty("articleCount") val articleCount: Int,
+)

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/FeedArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/FeedArticleUseCase.kt
@@ -1,0 +1,44 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import org.springframework.stereotype.Service
+
+/**
+ * 作成済記事一覧表示ユースケース
+ *
+ */
+interface FeedArticleUseCase {
+    /**
+     * 作成済記事一覧表示ユースケースの DTO
+     *
+     * @property articles
+     * @property articlesCount
+     */
+    data class FeedCreatedArticles(
+        val articles: List<CreatedArticle>,
+        val articlesCount: Int,
+    )
+
+    /**
+     * 作成済記事一覧表示ユースケースの実行メソッド
+     *
+     * @return
+     */
+    fun execute(): Either<Error, FeedCreatedArticles> = throw NotImplementedError()
+
+    /**
+     * 作成済記事一覧表示ユースケースのエラー
+     *
+     * エラーになるパターンが存在しない
+     *
+     */
+    sealed interface Error
+}
+
+/**
+ * 作成済記事一覧表示ユースケースの具象クラス
+ *
+ */
+@Service
+class FeedArticleUseCaseImpl : FeedArticleUseCase

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/FeedArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/FeedArticleUseCase.kt
@@ -1,6 +1,9 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
 import org.springframework.stereotype.Service
 
@@ -39,6 +42,19 @@ interface FeedArticleUseCase {
 /**
  * 作成済記事一覧表示ユースケースの具象クラス
  *
+ * @property articleRepository
  */
 @Service
-class FeedArticleUseCaseImpl : FeedArticleUseCase
+class FeedArticleUseCaseImpl(val articleRepository: ArticleRepository) : FeedArticleUseCase {
+    override fun execute(): Either<FeedArticleUseCase.Error, FeedArticleUseCase.FeedCreatedArticles> {
+        /**
+         * 記事を全て取得する
+         */
+        val createdArticles = articleRepository.all().getOrElse { throw UnsupportedOperationException("想定外のエラー") }
+
+        return FeedArticleUseCase.FeedCreatedArticles(
+            articles = createdArticles,
+            articlesCount = createdArticles.size
+        ).right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -455,4 +455,108 @@ class ArticleTest {
             )
         }
     }
+
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class GetArticles(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        fun `正常系-DB 内に存在する全ての記事を取得する`() {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = 200
+            val expectedResponseBody = """
+                {
+                    "articleCount": 2,
+                    "articles": [
+                        {
+                            "slug": "slug0000000000000000000000000001",
+                            "title": "dummy-title-01",
+                            "description": "dummy-description-01",
+                            "body": "dummy-body-01"
+                        },
+                        {
+                            "slug": "slug0000000000000000000000000002",
+                            "title": "dummy-title-02",
+                            "description": "dummy-description-02",
+                            "body": "dummy-body-02"
+                        }
+                    ]
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `正常系-DB 内に記事が存在しない場合、空で取得する`() {
+            /**
+             * given:
+             */
+
+            /**
+             * when:
+             */
+            val response = mockMvc.get("/api/articles") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = 200
+            val expectedResponseBody = """
+                {
+                  "articleCount": 0,
+                  "articles": []
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+    }
 }


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.4 記事単一取得 API の実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- OpenAPI Generator から SpringDoc を利用した実装に変更
- infra 層のテストを削除
