### PR TITLE
feat: 「📃3.7 記事更新取得 API の実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -55,4 +55,26 @@ interface ArticleRepository {
      * エラーになるパターンが存在しない
      */
     sealed interface FindError
+
+    /**
+     * 作成記事の更新
+     *
+     * @param slug
+     * @param updatableCreatedArticle
+     * @return
+     */
+    fun update(slug: Slug, updatableCreatedArticle: UpdatableCreatedArticle): Either<UpdateError, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * ArticleRepository.update のエラーインタフェース
+     *
+     */
+    sealed interface UpdateError {
+        /**
+         * slug に該当する記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFound(val slug: Slug) : UpdateError
+    }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/UpdatableCreatedArticle.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/UpdatableCreatedArticle.kt
@@ -1,0 +1,70 @@
+package com.example.implementingserversidekotlindevelopment.domain
+
+import arrow.core.EitherNel
+import arrow.core.raise.either
+import arrow.core.raise.zipOrAccumulate
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+
+/**
+ * 更新用の作成済記事インタフェース
+ *
+ */
+interface UpdatableCreatedArticle {
+    /**
+     * Title 更新用の作成済記事のタイトル
+     */
+    val title: Title
+
+    /**
+     * Description 更新用の作成済記事の概要
+     */
+    val description: Description
+
+    /**
+     * Body 更新用の作成済記事の本文
+     */
+    val body: Body
+
+    /**
+     * バリデーション済の更新用作成済記事
+     *
+     * @property title
+     * @property description
+     * @property body
+     */
+    private data class ValidatedUpdatableCreatedArticle(
+        override val title: Title,
+        override val description: Description,
+        override val body: Body,
+    ) : UpdatableCreatedArticle
+
+    companion object {
+        /**
+         * 作成済記事の更新
+         *
+         * @param title
+         * @param description
+         * @param body
+         * @return
+         */
+        fun new(
+            title: String,
+            description: String,
+            body: String,
+        ): EitherNel<ValidationError, UpdatableCreatedArticle> {
+            return either {
+                zipOrAccumulate(
+                    { Title.new(title).bindNel() },
+                    { Description.new(description).bindNel() },
+                    { Body.new(body).bindNel() },
+                ) { validatedTitle, validatedDescription, validatedBody ->
+                    ValidatedUpdatableCreatedArticle(
+                        validatedTitle,
+                        validatedDescription,
+                        validatedBody
+                    )
+                }
+            }
+        }
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/UpdateArticle.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/UpdateArticle.kt
@@ -1,0 +1,68 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.hibernate.validator.constraints.Length
+
+/**
+ * 更新記事
+ *
+ * @property title 作成済記事の更新後タイトル
+ * @property description 新規作成記事の更新後説明
+ * @property body 新規作成記事の更新後本文
+ */
+data class UpdateArticle(
+    @Schema(example = "null", description = "")
+    @field:Valid
+    @field:NotBlank
+    @field:Length(min = 0, max = 32)
+    @field:JsonProperty("title") private val title: String? = null,
+
+    @Schema(example = "null", description = "")
+    @field:Valid
+    @field:Length(min = 0, max = 64)
+    @field:NotNull
+    @field:JsonProperty("description") private val description: String? = null,
+
+    @Schema(example = "null", description = "")
+    @field:Valid
+    @field:Length(min = 0, max = 1024)
+    @field:NotNull
+    @field:JsonProperty("body") private val body: String? = null
+) {
+    /**
+     * 作成済記事の更新後タイトル
+     *
+     * @NotBlank アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedTitle: String
+        get() = title!!
+
+    /**
+     * 新規作成記事の更新後説明
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedDescription: String
+        get() = description!!
+
+    /**
+     * 新規作成記事の更新後本文
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     *
+     * @return
+     */
+    @get:Schema(hidden = true)
+    val validatedBody: String
+        get() = body!!
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/UpdateArticleRequest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/presentation/model/UpdateArticleRequest.kt
@@ -1,0 +1,27 @@
+package com.example.implementingserversidekotlindevelopment.presentation.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 更新記事のリクエストモデル
+ *
+ * @property article
+ */
+data class UpdateArticleRequest(
+    @field:Valid
+    @Schema(example = "null", required = true, description = "")
+    @field:NotNull
+    @field:JsonProperty("article", required = true) private val article: UpdateArticle? = null
+) {
+    /**
+     * 新規作成記事のプロパティ
+     *
+     * @NotNull アノテーションを付与しているため、null 非許容型に変換
+     */
+    @get:Schema(hidden = true)
+    val validatedArticle: UpdateArticle
+        get() = article!!
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/UpdateArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/UpdateArticleUseCase.kt
@@ -1,0 +1,57 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import org.springframework.stereotype.Service
+
+/**
+ * 記事更新ユースケース
+ *
+ */
+interface UpdateArticleUseCase {
+    /**
+     * 記事更新
+     *
+     * @param title
+     * @param description
+     * @param body
+     * @return
+     */
+    fun execute(slug: String, title: String, description: String, body: String): Either<Error, CreatedArticle> = throw NotImplementedError()
+
+    /**
+     * 記事更新ユースケースのエラー
+     *
+     */
+    sealed interface Error {
+        /**
+         * バリデーションエラー
+         *
+         * @property errors
+         */
+        data class ValidationErrors(val errors: List<ValidationError>) : Error
+
+        /**
+         * 不正な記事
+         *
+         * @property errors
+         */
+        data class InvalidArticle(val errors: List<ValidationError>) : Error
+
+        /**
+         * slug から記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFoundArticleBySlug(val slug: Slug) : Error
+    }
+}
+
+/**
+ * 記事更新ユースケースの具象クラス
+ *
+ */
+@Service
+class UpdateArticleUseCaseImpl : UpdateArticleUseCase

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/UpdateArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/UpdateArticleUseCase.kt
@@ -1,8 +1,13 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.CreatedArticle
 import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.domain.UpdatableCreatedArticle
 import com.example.implementingserversidekotlindevelopment.util.ValidationError
 import org.springframework.stereotype.Service
 
@@ -52,6 +57,30 @@ interface UpdateArticleUseCase {
 /**
  * 記事更新ユースケースの具象クラス
  *
+ * @property articleRepository
  */
 @Service
-class UpdateArticleUseCaseImpl : UpdateArticleUseCase
+class UpdateArticleUseCaseImpl(val articleRepository: ArticleRepository) : UpdateArticleUseCase {
+    override fun execute(slug: String, title: String, description: String, body: String): Either<UpdateArticleUseCase.Error, CreatedArticle> {
+        /**
+         * slug のバリデーション
+         *
+         * 不正だった場合、早期 return
+         */
+        val validatedSlug = Slug.new(slug).getOrElse { return UpdateArticleUseCase.Error.ValidationErrors(it).left() }
+
+        /**
+         * 更新用作成済記事の生成
+         *
+         * 不正だった場合、早期 return
+         */
+        val unsavedUpdatableArticle = UpdatableCreatedArticle.new(title, description, body).getOrElse { return UpdateArticleUseCase.Error.ValidationErrors(it).left() }
+
+        /**
+         * 作成済記事の更新
+         */
+        val createdArticle = articleRepository.update(validatedSlug, unsavedUpdatableArticle).getOrElse { return UpdateArticleUseCase.Error.NotFoundArticleBySlug(validatedSlug).left() }
+
+        return createdArticle.right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
 
 class ArticleTest {
     @SpringBootTest
@@ -556,6 +557,305 @@ class ArticleTest {
                 expectedResponseBody,
                 actualResponseBody,
                 JSONCompareMode.NON_EXTENSIBLE
+            )
+        }
+    }
+
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class UpdateArticle(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        @ExpectedDataSet(
+            value = ["datasets/yml/then/updated-articles.yml"],
+            orderBy = ["id"],
+        )
+        fun `正常系-slug に該当する作成済記事が更新される`() {
+            /**
+             * given:
+             */
+            val slug = "slug0000000000000000000000000001"
+            val requestBody = """
+                {
+                  "article": {
+                    "title": "updated-dummy-title-01",
+                    "description": "updated-dummy-description-01",
+                    "body": "updated-dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.put("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             * - JSON レスポンスを比較する。slug は自動生成されるので、形式だけ確認する
+             */
+            val expectedStatus = HttpStatus.OK.value()
+            val expectedResponseBody = """
+                {
+                  "article": {
+                    "slug": "slug0000000000000000000000000001",
+                    "title": "updated-dummy-title-01",
+                    "description": "updated-dummy-description-01",
+                    "body": "updated-dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                CustomComparator(
+                    JSONCompareMode.STRICT,
+                )
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-slug に該当する作成済記事が存在しない`() {
+            /**
+             * given:
+             * - DB に存在しない作成済記事
+             */
+            val slug = "slug0000000000000000000000000001"
+            val requestBody = """
+                {
+                  "article": {
+                    "title": "updated-dummy-title-01",
+                    "description": "updated-dummy-description-01",
+                    "body": "updated-dummy-body-01"
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.put("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.NOT_FOUND.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug0000000000000000000000000001 に該当する記事は見つかりませんでした"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.STRICT,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title、description、body がないときバリデーションエラー`() {
+            /**
+             * given:
+             * - title、description、body がない
+             */
+            val slug = "slug0000000000000000000000000001"
+            val responseBody = """
+                {
+                  "article": {}
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.put("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.descriptionは必須です",
+                            "article.titleは必須です",
+                            "article.bodyは必須です"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title は必須`() {
+            /**
+             * given:
+             * - title が 空白
+             */
+            val slug = "slug0000000000000000000000000001"
+            val title = ""
+            val responseBody = """
+                {
+                  "article": {
+                    "title": "$title",
+                    "description": "",
+                    "body": ""
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.put("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.titleは必須です"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー title が 33 文字以上、description が 65 文字以上、body が 1025 文字以上`() {
+            /**
+             * given:
+             * - title が 32 文字超過
+             * - description が 64 文字超過
+             * - body が 1024 文字超過
+             */
+            val slug = "slug0000000000000000000000000001"
+            val title = "a".repeat(33)
+            val description = "a".repeat(65)
+            val body = "a".repeat(1025)
+            val responseBody = """
+                {
+                  "article": {
+                    "title": "$title",
+                    "description": "$description",
+                    "body": "$body"
+                  }
+                }
+            """.trimIndent()
+
+            /**
+             * when:
+             */
+            val response = mockMvc.put("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+                content = responseBody
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "article.titleは0文字以上32文字以下にしてください",
+                            "article.bodyは0文字以上1024文字以下にしてください",
+                            "article.descriptionは0文字以上64文字以下にしてください"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
             )
         }
     }

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/updated-articles.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/updated-articles.yml
@@ -1,0 +1,11 @@
+articles:
+  - id: 2
+    title: "dummy-title-02"
+    slug: "slug0000000000000000000000000002"
+    body: "dummy-body-02"
+    description: "dummy-description-02"
+  - id: 1
+    title: "updated-dummy-title-01"
+    slug: "slug0000000000000000000000000001"
+    body: "updated-dummy-body-01"
+    description: "updated-dummy-description-01"


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.7 記事更新 API の実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- OpenAPI Generator から SpringDoc を利用した実装に変更
- infra 層のテストを削除
