### PR TITLE
feat: 「📃3.8 記事削除 API の実装」を作成

### DIFF
--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/domain/ArticleRepository.kt
@@ -77,4 +77,25 @@ interface ArticleRepository {
          */
         data class NotFound(val slug: Slug) : UpdateError
     }
+
+    /**
+     * 作成済記事の削除
+     *
+     * @param slug
+     * @return
+     */
+    fun delete(slug: Slug): Either<DeleteError, Unit> = throw NotImplementedError()
+
+    /**
+     * ArticleRepository.delete のエラーインタフェース
+     *
+     */
+    sealed interface DeleteError {
+        /**
+         * 記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFound(val slug: Slug) : DeleteError
+    }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/infra/ArticleRepositoryImpl.kt
@@ -159,4 +159,52 @@ class ArticleRepositoryImpl(val namedParameterJdbcTemplate: NamedParameterJdbcTe
             description = updatableCreatedArticle.description
         ).right()
     }
+
+    override fun delete(slug: Slug): Either<ArticleRepository.DeleteError, Unit> {
+        /**
+         * slug に該当する作成済記事を調べる
+         */
+        val findArticleSql = """
+            SELECT
+                articles.slug
+                , articles.title
+                , articles.body
+                , articles.description
+            FROM
+                articles
+            WHERE
+                slug = :slug
+            ;
+        """.trimIndent()
+        val articleMapList =
+            namedParameterJdbcTemplate.queryForList(
+                findArticleSql,
+                MapSqlParameterSource().addValue("slug", slug.value)
+            )
+
+        /**
+         * DB から作成済記事が見つからなかった場合、早期 return
+         */
+        if (articleMapList.isEmpty()) {
+            return ArticleRepository.DeleteError.NotFound(slug = slug).left()
+        }
+
+        /**
+         * 記事を削除
+         */
+        val sql = """
+            DELETE FROM
+                articles
+            WHERE
+                slug = :slug
+            ;
+        """.trimIndent()
+        namedParameterJdbcTemplate.update(
+            sql,
+            MapSqlParameterSource()
+                .addValue("slug", slug.value)
+        )
+
+        return Unit.right()
+    }
 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/DeleteCreatedArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/DeleteCreatedArticleUseCase.kt
@@ -1,6 +1,10 @@
 package com.example.implementingserversidekotlindevelopment.usecase
 
 import arrow.core.Either
+import arrow.core.getOrElse
+import arrow.core.left
+import arrow.core.right
+import com.example.implementingserversidekotlindevelopment.domain.ArticleRepository
 import com.example.implementingserversidekotlindevelopment.domain.Slug
 import com.example.implementingserversidekotlindevelopment.util.ValidationError
 import org.springframework.stereotype.Service
@@ -42,6 +46,30 @@ interface DeleteCreatedArticleUseCase {
 /**
  * 記事削除ユースケースの具象クラス
  *
+ * @property articleRepository
  */
 @Service
-class DeleteCreatedArticleUseCaseImpl : DeleteCreatedArticleUseCase
+class DeleteCreatedArticleUseCaseImpl(val articleRepository: ArticleRepository) : DeleteCreatedArticleUseCase {
+    override fun execute(slug: String): Either<DeleteCreatedArticleUseCase.Error, Unit> {
+        /**
+         * slug のバリデーション
+         *
+         * 不正だった場合、早期 return
+         */
+        val validatedSlug = Slug.new(slug = slug).getOrElse { return DeleteCreatedArticleUseCase.Error.ValidationErrors(it).left() }
+
+        /**
+         * 作成済記事の削除
+         *
+         * slug に該当する記事が存在しない場合、早期 return
+         */
+        articleRepository.delete(validatedSlug).getOrElse {
+            return when (it) {
+                is ArticleRepository.DeleteError.NotFound ->
+                    DeleteCreatedArticleUseCase.Error.NotFoundArticleBySlug(validatedSlug).left()
+            }
+        }
+
+        return Unit.right()
+    }
+}

--- a/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/DeleteCreatedArticleUseCase.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/main/kotlin/com/example/implementingserversidekotlindevelopment/usecase/DeleteCreatedArticleUseCase.kt
@@ -1,0 +1,47 @@
+package com.example.implementingserversidekotlindevelopment.usecase
+
+import arrow.core.Either
+import com.example.implementingserversidekotlindevelopment.domain.Slug
+import com.example.implementingserversidekotlindevelopment.util.ValidationError
+import org.springframework.stereotype.Service
+
+/**
+ * 記事削除ユースケース
+ *
+ */
+interface DeleteCreatedArticleUseCase {
+    /**
+     * 記事削除
+     *
+     * @param slug
+     * @return
+     */
+    fun execute(slug: String): Either<Error, Unit> = throw NotImplementedError()
+
+    /**
+     * 記事削除ユースケースのエラー
+     *
+     */
+    sealed interface Error {
+        /**
+         * バリデーションエラー
+         *
+         * @property errors
+         */
+        data class ValidationErrors(val errors: List<ValidationError>) : Error
+
+        /**
+         * Slug に該当する記事が見つからなかった
+         *
+         * @property slug
+         */
+        data class NotFoundArticleBySlug(val slug: Slug) : Error
+    }
+}
+
+/**
+ * 記事削除ユースケースの具象クラス
+ *
+ */
+@Service
+class DeleteCreatedArticleUseCaseImpl : DeleteCreatedArticleUseCase

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/kotlin/com/example/implementingserversidekotlindevelopment/api/integration/ArticleTest.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
@@ -847,6 +848,195 @@ class ArticleTest {
                             "article.titleは0文字以上32文字以下にしてください",
                             "article.bodyは0文字以上1024文字以下にしてください",
                             "article.descriptionは0文字以上64文字以下にしてください"
+                        ]
+                    }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+    }
+
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DBRider
+    class DeleteArticle(
+        @Autowired val mockMvc: MockMvc,
+    ) {
+        @BeforeEach
+        fun reset() = DbConnection.resetSequence()
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/articles.yml"
+            ]
+        )
+        @ExpectedDataSet(
+            value = ["datasets/yml/then/deleted-articles.yml"],
+            orderBy = ["id"],
+        )
+        fun `正常系-slug に該当する作成済記事が削除される`() {
+            /**
+             * given:
+             * - 存在する slug
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.delete("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             * - JSON レスポンスを比較する。slug は自動生成されるので、形式だけ確認する
+             */
+            val expectedStatus = HttpStatus.OK.value()
+            val expectedResponseBody = "{}".trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.STRICT
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-slug に該当する作成済記事が存在しない`() {
+            /**
+             * given:
+             * - 存在しない slug
+             */
+            val slug = "slug0000000000000000000000000001"
+
+            /**
+             * when:
+             */
+            val response = mockMvc.delete("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.NOT_FOUND.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slug0000000000000000000000000001 に該当する記事は見つかりませんでした"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー slug が 33 文字以上`() {
+            /**
+             * given:
+             * - 33 文字（32 文字以上）の slug
+             */
+            val slug = "a".repeat(33)
+
+            /**
+             * when:
+             */
+            val response = mockMvc.delete("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                  "errors": {
+                    "body": [
+                      "slugは32文字以上32文字以下にしてください"
+                    ]
+                  }
+                }
+            """.trimIndent()
+            assertThat(actualStatus).isEqualTo(expectedStatus)
+            JSONAssert.assertEquals(
+                expectedResponseBody,
+                actualResponseBody,
+                JSONCompareMode.NON_EXTENSIBLE,
+            )
+        }
+
+
+        @Test
+        @DataSet(
+            value = [
+                "datasets/yml/given/empty-articles.yml"
+            ]
+        )
+        fun `異常系-バリデーションエラー slug が 31 文字以下`() {
+            /**
+             * given:
+             * - 31 文字（32 文字以下）の slug
+             */
+            val slug = "a".repeat(31)
+
+            /**
+             * when:
+             */
+            val response = mockMvc.delete("/api/articles/$slug") {
+                contentType = MediaType.APPLICATION_JSON
+            }.andReturn().response
+            val actualStatus = response.status
+            val actualResponseBody = response.contentAsString
+
+            /**
+             * then:
+             * - ステータスコードが一致する
+             * - レスポンスボディが一致する
+             */
+            val expectedStatus = HttpStatus.BAD_REQUEST.value()
+            val expectedResponseBody = """
+                {
+                    "errors": {
+                        "body": [
+                            "slugは32文字以上32文字以下にしてください"
                         ]
                     }
                 }

--- a/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/deleted-articles.yml
+++ b/chapter-03/implementing-server-side-kotlin-development/src/test/resources/datasets/yml/then/deleted-articles.yml
@@ -1,0 +1,6 @@
+articles:
+  - id: 2
+    title: "dummy-title-02"
+    slug: "slug0000000000000000000000000002"
+    body: "dummy-body-02"
+    description: "dummy-description-02"


### PR DESCRIPTION
## PR 作成の目的

「ハンズオンで学ぶサーバーサイド Kotlin」の Spring Boot 3 対応に合わせて、「📃3.8 記事削除 API の実装」を更新。

[feature-#64/migrate-spring-boot-3/master](https://github.com/Msksgm/hands-on-server-side-kotlin/tree/feature-%2364/migrate-spring-boot-3/master) ブランチにマージして最終的に master ブランチにマージする。

## 変更概要

- OpenAPI Generator から SpringDoc を利用した実装に変更
- infra 層のテストを削除
