### PR TITLE
chore: 「📘第 1 章 Kotlin 入門」を Kotlin v1.9.23 に更新

### DIFF
--- a/chapter-01/kotlin-fizzbuzz/build.gradle.kts
+++ b/chapter-01/kotlin-fizzbuzz/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm") version "1.8.0"
-    application
+    kotlin("jvm") version "1.9.23"
 }
 
 group = "org.example"
@@ -19,11 +16,6 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-application {
-    mainClass.set("MainKt")
+kotlin {
+    jvmToolchain(17)
 }

--- a/chapter-01/kotlin-fizzbuzz/gradle/wrapper/gradle-wrapper.properties
+++ b/chapter-01/kotlin-fizzbuzz/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jun 26 09:35:41 JST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/chapter-01/kotlin-fizzbuzz/settings.gradle.kts
+++ b/chapter-01/kotlin-fizzbuzz/settings.gradle.kts
@@ -1,3 +1,5 @@
-
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+}
 rootProject.name = "kotlin-fizzbuzz"
 

--- a/chapter-01/kotlin-fizzbuzz/src/main/kotlin/fizzbuzz_when/main.kt
+++ b/chapter-01/kotlin-fizzbuzz/src/main/kotlin/fizzbuzz_when/main.kt
@@ -42,29 +42,9 @@ fun fizzBuzz2(i: Int): String {
     }
 }
 
-fun fizzBuzz3(i: Int): String {
-    return when {
-        i % 15 == 0 -> {
-            "FizzBuzz"
-        }
-
-        i % 5 == 0 -> {
-            "Fizz"
-        }
-
-        i % 3 == 0 -> {
-            "Buzz"
-        }
-
-        else -> {
-            "$i"
-        }
-    }
-}
-
 fun main(args: Array<String>) {
     println(fizzBuzz1(15))
     println(fizzBuzz2(5))
-    println(fizzBuzz3(3))
-    println(fizzBuzz3(1))
+    println(fizzBuzz2(3))
+    println(fizzBuzz2(1))
 }

--- a/chapter-01/kotlin-helloworld/.gitignore
+++ b/chapter-01/kotlin-helloworld/.gitignore
@@ -1,0 +1,42 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/chapter-01/kotlin-helloworld/build.gradle.kts
+++ b/chapter-01/kotlin-helloworld/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm") version "1.8.0"
-    application
+    kotlin("jvm") version "1.9.23"
 }
 
 group = "org.example"
@@ -19,11 +16,6 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-application {
-    mainClass.set("MainKt")
+kotlin {
+    jvmToolchain(17)
 }

--- a/chapter-01/kotlin-helloworld/gradle/wrapper/gradle-wrapper.properties
+++ b/chapter-01/kotlin-helloworld/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jun 26 08:48:20 JST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/chapter-01/kotlin-helloworld/settings.gradle.kts
+++ b/chapter-01/kotlin-helloworld/settings.gradle.kts
@@ -1,3 +1,5 @@
-
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.5.0"
+}
 rootProject.name = "kotlin-helloworld"
 


### PR DESCRIPTION
## 概要

 「📘第 1 章 Kotlin 入門」における Kotlin のバージョンを v1.9.23 に更新しました。
Intellij IDEA のプロジェクト作成機能を利用しているため、build.gradkle.kts 以外にも更新が入っています。

## issue


- https://github.com/Msksgm/hands-on-server-side-kotlin/issues/80